### PR TITLE
Ps3 demo deadband

### DIFF
--- a/Linux/project/ps3_demo/StatusCheck.h
+++ b/Linux/project/ps3_demo/StatusCheck.h
@@ -71,6 +71,7 @@ namespace Robot
 			static minIni* m_ini;
 			static minIni* m_ini1;
 			static void Check(ArbotixPro &arbotixpro);
+			static void DeadBand( int p_deadband, int p_value );
 	};
 }
 #endif /* STATUSCHECK_H_ */

--- a/Linux/project/ps3_demo/StatusCheck.h
+++ b/Linux/project/ps3_demo/StatusCheck.h
@@ -71,7 +71,7 @@ namespace Robot
 			static minIni* m_ini;
 			static minIni* m_ini1;
 			static void Check(ArbotixPro &arbotixpro);
-			static void DeadBand( int p_deadband, int p_value );
+			static int DeadBand( int p_deadband, int p_value );
 	};
 }
 #endif /* STATUSCHECK_H_ */


### PR DESCRIPTION
Previous method removed dead band from only one side of the joystick. This PR contains a new and tested method of calculating the dead band.

This fix should also apply to the HR-OS1.
